### PR TITLE
Adding bypass for gitlab ci

### DIFF
--- a/index.js
+++ b/index.js
@@ -78,12 +78,27 @@ function dockerPostgres(dockerOpts) {
     // set the timeout of the hook long enough for the container to start
     this.timeout(10000);
     return new Promise(function (resolve, reject) {
-        waitForDockerContainerToBeReady(dockerOpts, passError(reject, function () {
-            state.containerReference.getConString(databaseName, passError(reject, function (conString) {
+        if (process.env.GITLAB_CI) {
+            var pgUser = process.env.POSTGRES_USER;
+            var pgPassword = process.env.POSTGRES_PASSWORD;
+            var port = process.env.POSTGRES_PORT_5432_TCP_PORT;
+            var ip = process.env.POSTGRES_PORT_5432_TCP_ADDR;
+
+            PostgresContainer.prototype.getConString.call({
+                conString: 'postgres://' + pgUser + ':' + pgPassword + '@' + ip + ':' + port + '/{database}',
+                pgUser: pgUser
+            }, databaseName, passError(reject, function (conString) {
                 that.conString = conString;
                 resolve();
             }));
-        }));
+        } else {
+            waitForDockerContainerToBeReady(dockerOpts, passError(reject, function () {
+                state.containerReference.getConString(databaseName, passError(reject, function (conString) {
+                    that.conString = conString;
+                    resolve();
+                }));
+            }));
+        }
     });
 }
 

--- a/index.js
+++ b/index.js
@@ -78,11 +78,17 @@ function dockerPostgres(dockerOpts) {
     // set the timeout of the hook long enough for the container to start
     this.timeout(10000);
     return new Promise(function (resolve, reject) {
-        if (process.env.GITLAB_CI) {
+        if (
+            process.env.POSTGRES_USER ||
+            process.env.POSTGRES_PASSWORD ||
+            process.env.POSTGRES_PORT
+        ) {
             var pgUser = process.env.POSTGRES_USER;
             var pgPassword = process.env.POSTGRES_PASSWORD;
-            var port = process.env.POSTGRES_PORT_5432_TCP_PORT;
-            var ip = process.env.POSTGRES_PORT_5432_TCP_ADDR;
+            var pgPort = process.env.POSTGRES_PORT;
+
+            var ip = pgPort.split(':')[1].substr(2);
+            var port = pgPort.split(':')[2];
 
             PostgresContainer.prototype.getConString.call({
                 conString: 'postgres://' + pgUser + ':' + pgPassword + '@' + ip + ':' + port + '/{database}',

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   },
   "devDependencies": {
     "mocha": "2.3.3",
+    "proxyquire": "1.7.11",
     "unexpected": "10.0.2"
   },
   "dependencies": {

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -1,0 +1,41 @@
+var expect = require('unexpected');
+var proxyquire = require('proxyquire');
+
+describe('dockerPostgres', function () {
+    proxyquire('../index', {
+        './PostgresContainer': proxyquire('../lib/PostgresContainer', {
+            './executeSql': function(conString, query, cb) { return cb(); }
+        })
+    });
+
+    describe('when running on Gitlab CI server', function () {
+        before(function () {
+            process.env.GITLAB_CI = 'true';
+            process.env.POSTGRES_USER = 'foo';
+            process.env.POSTGRES_PASSWORD = 'bar';
+            process.env.POSTGRES_PORT_5432_TCP_PORT = 5432;
+            process.env.POSTGRES_PORT_5432_TCP_ADDR = '0.0.0.0';
+        });
+
+        after(function () {
+            delete process.env.GITLAB_CI;
+            delete process.env.POSTGRES_USER;
+            delete process.env.POSTGRES_PASSOWRD;
+            delete process.env.POSTGRES_PORT_5432_TCP_PORT;
+            delete process.env.POSTGRES_PORT_5432_TCP_ADDR;
+        });
+
+        it('should set the connection string for the env connection', function () {
+            var that = this;
+            return this.dockerPostgres({})
+                .then(function () {
+                    return expect(
+                        that.conString,
+                        'to contain',
+                         'postgres://foo:bar@0.0.0.0:5432/'
+                    );
+                })
+        });
+
+    });
+});

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -8,21 +8,26 @@ describe('dockerPostgres', function () {
         })
     });
 
-    describe('when running on Gitlab CI server', function () {
+    describe('when running on a CI server with a liked Postgres container', function () {
+        var originalValues = {};
+
         before(function () {
-            process.env.GITLAB_CI = 'true';
+            originalValues.CI = process.env.CI;
+            originalValues.POSTGRES_USER = process.env.POSTGRES_USER;
+            originalValues.POSTGRES_PASSWORD = process.env.POSTGRES_PASSWORD;
+            originalValues.POSTGRES_PORT = process.env.POSTGRES_PORT;
+
+            process.env.CI = true;
             process.env.POSTGRES_USER = 'foo';
             process.env.POSTGRES_PASSWORD = 'bar';
-            process.env.POSTGRES_PORT_5432_TCP_PORT = 5432;
-            process.env.POSTGRES_PORT_5432_TCP_ADDR = '0.0.0.0';
+            process.env.POSTGRES_PORT = 'tcp://0.0.0.0:5432';
         });
 
         after(function () {
-            delete process.env.GITLAB_CI;
-            delete process.env.POSTGRES_USER;
-            delete process.env.POSTGRES_PASSOWRD;
-            delete process.env.POSTGRES_PORT_5432_TCP_PORT;
-            delete process.env.POSTGRES_PORT_5432_TCP_ADDR;
+            originalValues.CI = process.env.CI;
+            process.env.POSTGRES_USER = originalValues.POSTGRES_USER;
+            process.env.POSTGRES_PASSWORD = originalValues.POSTGRES_PASSWORD;
+            process.env.POSTGRES_PORT = originalValues.POSTGRES_PORT;
         });
 
         it('should set the connection string for the env connection', function () {


### PR DESCRIPTION
Bypass `waitForDockerContainerToBeReady` when running on `GITLAB` and use the provisioned postgres instance instead.

